### PR TITLE
ContactsCommon: fix exporting SIM contacts the first time

### DIFF
--- a/src/com/android/contacts/common/interactions/ImportExportDialogFragment.java
+++ b/src/com/android/contacts/common/interactions/ImportExportDialogFragment.java
@@ -412,7 +412,6 @@ public class ImportExportDialogFragment extends AnalyticsDialogFragment
             // GoogleSource.createMyContactsIfNotExist(account, getActivity());
             // in case export is stopped, record the count of inserted successfully
             int insertCount = 0;
-            freeSimCount = MoreContactUtils.getSimFreeCount(mPeople,subscription);
 
             mSimContactsOperation = new SimContactsOperation(mPeople);
             Cursor cr = null;
@@ -437,7 +436,7 @@ public class ImportExportDialogFragment extends AnalyticsDialogFragment
                     cr.close();
                 }
             }
-
+            freeSimCount = MoreContactUtils.getSimFreeCount(mPeople,subscription);
             boolean canSaveAnr = MoreContactUtils.canSaveAnr(subscription);
             boolean canSaveEmail = MoreContactUtils.canSaveEmail(subscription);
             int emptyAnr = MoreContactUtils.getSpareAnrCount(subscription);


### PR DESCRIPTION
Iff the ICC cache hasn't populated before the cursor query - let it
populate, then get the free count.

Change-Id: Ic3e2d96e657ed61863b332d817d865ddbd107e55
Signed-off-by: Roman Birg <roman@cyngn.com>
(cherry picked from commit 2a99ff27231d9ca380ccb47877365f922c1bef64)